### PR TITLE
refactor to use a POST, add code to lock account after too many attempts

### DIFF
--- a/ldap-api/pom.xml
+++ b/ldap-api/pom.xml
@@ -29,6 +29,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.6.28</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/controller/UsersController.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/controller/UsersController.java
@@ -1,14 +1,9 @@
 package ca.bc.gov.hlth.ldapapi.controller;
 
+import ca.bc.gov.hlth.ldapapi.model.User;
+import ca.bc.gov.hlth.ldapapi.model.UserCredentials;
 import ca.bc.gov.hlth.ldapapi.service.LdapService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
-import java.util.Properties;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class UsersController {
@@ -19,9 +14,9 @@ public class UsersController {
         this.ldapService = ldapService;
     }
 
-    @GetMapping("/users/{userId}")
-    public Map<String, String> getUser(@PathVariable String userId, @RequestBody String userPassword) {
-        return ldapService.authenticate(userId, userPassword);
+    @PostMapping("/users")
+    public User getUser(@RequestBody UserCredentials userCredentials) {
+        return ldapService.authenticate(userCredentials);
     }
 
 }

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
@@ -1,0 +1,40 @@
+package ca.bc.gov.hlth.ldapapi.model;
+
+public class User {
+    private boolean authenticated;
+    private boolean unlocked;
+    private String username;
+    private String gisuserrole;
+
+    public boolean isAuthenticated() {
+        return authenticated;
+    }
+
+    public void setAuthenticated(boolean authenticated) {
+        this.authenticated = authenticated;
+    }
+
+    public boolean isUnlocked() {
+        return unlocked;
+    }
+
+    public void setUnlocked(boolean unlocked) {
+        this.unlocked = unlocked;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getGisuserrole() {
+        return gisuserrole;
+    }
+
+    public void setGisuserrole(String gisuserrole) {
+        this.gisuserrole = gisuserrole;
+    }
+}

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/UserCredentials.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/UserCredentials.java
@@ -1,0 +1,22 @@
+package ca.bc.gov.hlth.ldapapi.model;
+
+public class UserCredentials {
+    private String userName;
+    private String password;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -1,17 +1,20 @@
 package ca.bc.gov.hlth.ldapapi.service;
 
+import ca.bc.gov.hlth.ldapapi.model.User;
+import ca.bc.gov.hlth.ldapapi.model.UserCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Scope;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.naming.AuthenticationException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.*;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class LdapService {
@@ -20,17 +23,28 @@ public class LdapService {
     private final Properties ldapProperties;
 
     private final String LDAP_CONST_UNLOCKED = "unlocked";
+    private final String LDAP_CONST_LOCKED = "locked";
     private final String LDAP_CONST_ACCOUNT_LOCKED_ATTRIBUTE = "acctlockedflag";
+    public  final String LDAP_ATTR_ACCT_LOCKED_BY = "acctlockedby";
+    public static String LDAP_ATTR_ACCT_LOCKED_REASON = "acctlockedreason";
     private final String LDAP_SEARCH_BASE = "o=hnet,st=bc,c=ca";
+
+    @Value("${ldap.attempt.timeout}")
+    private int attemptTimeout;
+
+    private final ConcurrentHashMap<String, LoginAttempts> loginAttemptsMap = new ConcurrentHashMap<>();
 
     public LdapService(Properties ldapProperties) {
         this.ldapProperties = ldapProperties;
     }
 
-    public Map<String, String> authenticate(String username, String password) {
-        SearchResult userInfo = searchUser(username);
-        boolean validCredentials = authenticateUser(userInfo.getName(), password);
+    public User authenticate(UserCredentials userCredentials) {
+        SearchResult userInfo = searchUser(userCredentials.getUserName());
         boolean userUnlocked = checkUserLocked(userInfo.getAttributes());
+        boolean validCredentials = false;
+        if (userUnlocked) {
+            validCredentials = authenticateUser(userInfo.getName(), userCredentials.getPassword());
+        }
 
         return createReturnMessage(userInfo.getName(), validCredentials, userUnlocked, userInfo.getAttributes());
     }
@@ -53,30 +67,6 @@ public class LdapService {
         return null;
     }
 
-    private boolean authenticateUser(String userInfoName, String password) {
-
-        boolean userAuthenticated = false;
-
-        Properties userLdapProperties = (Properties) ldapProperties.clone();
-        userLdapProperties.put("java.naming.security.principal", userInfoName + "," + LDAP_SEARCH_BASE);
-        userLdapProperties.put("java.naming.security.credentials", password);
-        userLdapProperties.put("com.sun.jndi.ldap.connect.pool", "false");
-
-        try {
-            DirContext userContext = new InitialDirContext(userLdapProperties);
-            userAuthenticated = true;
-            userContext.close(); // close can also throw an exception
-        } catch (NamingException e) {
-            if (e instanceof AuthenticationException) {
-                webClientLogger.info("Failed authentication for user: " + userInfoName);
-            } else {
-                e.printStackTrace();
-            }
-        }
-
-        return userAuthenticated;
-    }
-
     private boolean checkUserLocked(Attributes attributes) {
         Attribute acctLockedFlag = attributes.get(LDAP_CONST_ACCOUNT_LOCKED_ATTRIBUTE);
         boolean unlocked = true;
@@ -93,26 +83,97 @@ public class LdapService {
         return unlocked;
     }
 
-    protected Map<String, String> createReturnMessage(String userName, boolean validCredentials, boolean userUnlocked, Attributes attributes) {
+    private boolean authenticateUser(String userInfoName, String password) {
 
-        Map<String, String> returnMessageMap = new HashMap<>();
-        returnMessageMap.put("Username", userName);
-        returnMessageMap.put("Authenticated", Boolean.toString(validCredentials));
-        returnMessageMap.put("Unlocked", Boolean.toString(userUnlocked));
+        boolean userAuthenticated = false;
+
+        Properties userLdapProperties = (Properties) ldapProperties.clone();
+        userLdapProperties.put("java.naming.security.principal", userInfoName + "," + LDAP_SEARCH_BASE);
+        userLdapProperties.put("java.naming.security.credentials", password);
+        userLdapProperties.put("com.sun.jndi.ldap.connect.pool", "false");
+
+        try {
+            DirContext userContext = new InitialDirContext(userLdapProperties);
+            userAuthenticated = true;
+            userContext.close(); // close can also throw an exception
+        } catch (NamingException e) {
+            if (e instanceof AuthenticationException) {
+                updateUserFailedLoginAttempts(userInfoName);
+                webClientLogger.info("Failed authentication for user: " + userInfoName);
+            } else {
+                e.printStackTrace();
+            }
+        }
+
+        return userAuthenticated;
+    }
+
+    private void updateUserFailedLoginAttempts(String userInfoName) {
+        LoginAttempts loginAttemptsForUser = loginAttemptsMap.get(userInfoName);
+        // No entry: add entry, set attempts=1, set timestamp=now
+        if (loginAttemptsForUser == null) {
+            LoginAttempts newLoginAttempts = new LoginAttempts(1, LocalDateTime.now());
+            loginAttemptsMap.put(userInfoName, newLoginAttempts);
+            return;
+        }
+
+        long hoursSinceLastAttempt = ChronoUnit.HOURS.between(loginAttemptsForUser.getLastAttempt(), LocalDateTime.now());
+        int currentAttempts = loginAttemptsForUser.getAttempts();
+        // Entry exists AND timestamp >1hr: set attempts=1, timestamp=now
+        if (hoursSinceLastAttempt > attemptTimeout) {
+            loginAttemptsForUser.setAttempts(1);
+            loginAttemptsForUser.setLastAttempt(LocalDateTime.now());
+
+        } else if (currentAttempts < 2) { // Entry Exists, timestamp<1hr, attempts<2: set attempts+1, timestamp=now
+            loginAttemptsForUser.setAttempts(currentAttempts + 1);
+            loginAttemptsForUser.setLastAttempt(LocalDateTime.now());
+
+        } else { // Entry Exists, timestamp<1hr, attempts >=3
+            lockUserAccount(userInfoName + "," + LDAP_SEARCH_BASE);
+        }
+    }
+
+    protected User createReturnMessage(String userName, boolean validCredentials, boolean userUnlocked, Attributes attributes) {
+
+        User userToReturn = new User();
+        userToReturn.setUsername(userName);
+        userToReturn.setAuthenticated(validCredentials);
+        userToReturn.setUnlocked(userUnlocked);
 
         // Role information is only relevant if the user is authenticated and unlocked
         if (validCredentials && userUnlocked) {
             Attribute gisUserRoleAttribute = attributes.get("gisuserrole");
             if (gisUserRoleAttribute != null) {
                 try {
-                    returnMessageMap.put(gisUserRoleAttribute.getID(), (String) gisUserRoleAttribute.get());
+                    userToReturn.setGisuserrole((String) gisUserRoleAttribute.get());
                 } catch (NamingException e) {
                     e.printStackTrace();
                 }
             }
         }
 
-        return returnMessageMap;
+        return userToReturn;
+    }
+
+    private void lockUserAccount(String userInfoName) {
+        try {
+            DirContext ctx = new InitialDirContext(ldapProperties);
+
+            ModificationItem lockedItem = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
+                    new BasicAttribute(LDAP_CONST_ACCOUNT_LOCKED_ATTRIBUTE, LDAP_CONST_LOCKED));
+            ModificationItem lockedReasonItem = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
+                    new BasicAttribute(LDAP_ATTR_ACCT_LOCKED_REASON, "User exceeded maximum login attempts"));
+            ModificationItem lockedByItem = new ModificationItem(DirContext.REPLACE_ATTRIBUTE,
+                    new BasicAttribute(LDAP_ATTR_ACCT_LOCKED_BY, "KeycloakEnrollment"));
+
+            ModificationItem[] changeItems = {lockedItem, lockedReasonItem, lockedByItem};
+
+            ctx.modifyAttributes(userInfoName, changeItems);
+
+        } catch (NamingException e) {
+            webClientLogger.info("Failed to lock user: " + userInfoName);
+            e.printStackTrace();
+        }
     }
 
 }

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -25,14 +25,14 @@ public class LdapService {
     private final String LDAP_CONST_UNLOCKED = "unlocked";
     private final String LDAP_CONST_LOCKED = "locked";
     private final String LDAP_CONST_ACCOUNT_LOCKED_ATTRIBUTE = "acctlockedflag";
-    public  final String LDAP_ATTR_ACCT_LOCKED_BY = "acctlockedby";
-    public static String LDAP_ATTR_ACCT_LOCKED_REASON = "acctlockedreason";
+    private final String LDAP_ATTR_ACCT_LOCKED_BY = "acctlockedby";
+    private final String LDAP_ATTR_ACCT_LOCKED_REASON = "acctlockedreason";
     private final String LDAP_SEARCH_BASE = "o=hnet,st=bc,c=ca";
 
     @Value("${ldap.attempt.timeout}")
-    private int attemptTimeout;
+    protected int attemptTimeout;
 
-    private final ConcurrentHashMap<String, LoginAttempts> loginAttemptsMap = new ConcurrentHashMap<>();
+    protected final ConcurrentHashMap<String, LoginAttempts> loginAttemptsMap = new ConcurrentHashMap<>();
 
     public LdapService(Properties ldapProperties) {
         this.ldapProperties = ldapProperties;
@@ -108,7 +108,7 @@ public class LdapService {
         return userAuthenticated;
     }
 
-    private void updateUserFailedLoginAttempts(String userInfoName) {
+    protected void updateUserFailedLoginAttempts(String userInfoName) {
         LoginAttempts loginAttemptsForUser = loginAttemptsMap.get(userInfoName);
         // No entry: add entry, set attempts=1, set timestamp=now
         if (loginAttemptsForUser == null) {
@@ -155,7 +155,7 @@ public class LdapService {
         return userToReturn;
     }
 
-    private void lockUserAccount(String userInfoName) {
+    protected void lockUserAccount(String userInfoName) {
         try {
             DirContext ctx = new InitialDirContext(ldapProperties);
 
@@ -169,6 +169,7 @@ public class LdapService {
             ModificationItem[] changeItems = {lockedItem, lockedReasonItem, lockedByItem};
 
             ctx.modifyAttributes(userInfoName, changeItems);
+            webClientLogger.info("User locked: " + userInfoName);
 
         } catch (NamingException e) {
             webClientLogger.info("Failed to lock user: " + userInfoName);

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LoginAttempts.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LoginAttempts.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.hlth.ldapapi.service;
+
+import java.time.LocalDateTime;
+
+public class LoginAttempts {
+    private int attempts;
+    private LocalDateTime lastAttempt;
+
+    public LoginAttempts(int attempts, LocalDateTime lastAttempt) {
+        this.attempts = attempts;
+        this.lastAttempt = lastAttempt;
+    }
+
+    public int getAttempts() {
+        return attempts;
+    }
+
+    public void setAttempts(int attempts) {
+        this.attempts = attempts;
+    }
+
+    public LocalDateTime getLastAttempt() {
+        return lastAttempt;
+    }
+
+    public void setLastAttempt(LocalDateTime lastAttempt) {
+        this.lastAttempt = lastAttempt;
+    }
+}

--- a/ldap-api/src/main/resources/application.properties
+++ b/ldap-api/src/main/resources/application.properties
@@ -2,3 +2,6 @@ ldap.provider.url=
 ldap.security.authentication=
 ldap.security.principal=
 ldap.security.credentials=
+ldap.attempt.timeout=
+server.port=
+spring.jackson.default-property-inclusion=non_null

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -1,10 +1,10 @@
 package ca.bc.gov.hlth.ldapapi.service;
 
+import ca.bc.gov.hlth.ldapapi.model.User;
 import org.junit.jupiter.api.Test;
 
 import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttributes;
-import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,37 +19,37 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedFalse() {
-        Map<String, String> returnMessageMap = ldapService.createReturnMessage(userName, false, true, attributesWithRole);
-        assertEquals(userName, returnMessageMap.get("Username"));
-        assertEquals("false", returnMessageMap.get("Authenticated"));
-        assertEquals("true", returnMessageMap.get("Unlocked"));
-        assertNull(returnMessageMap.get("gisuserrole"));
+        User returnedUser = ldapService.createReturnMessage(userName, false, true, attributesWithRole);
+        assertEquals(userName, returnedUser.getUsername());
+        assertEquals(false, returnedUser.isAuthenticated());
+        assertEquals(true, returnedUser.isUnlocked());
+        assertNull(returnedUser.getGisuserrole());
     }
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_userUnlockedFalse() {
-        Map<String, String> returnMessageMap = ldapService.createReturnMessage(userName, true, false, attributesWithRole);
-        assertEquals(userName, returnMessageMap.get("Username"));
-        assertEquals("true", returnMessageMap.get("Authenticated"));
-        assertEquals("false", returnMessageMap.get("Unlocked"));
-        assertNull(returnMessageMap.get("gisuserrole"));
+        User returnedUser = ldapService.createReturnMessage(userName, true, false, attributesWithRole);
+        assertEquals(userName, returnedUser.getUsername());
+        assertEquals(true, returnedUser.isAuthenticated());
+        assertEquals(false, returnedUser.isUnlocked());
+        assertNull(returnedUser.getGisuserrole());
     }
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleFalse() {
-        Map<String, String> returnMessageMap = ldapService.createReturnMessage(userName, true, true, attributesWithoutRole);
-        assertEquals(userName, returnMessageMap.get("Username"));
-        assertEquals("true", returnMessageMap.get("Authenticated"));
-        assertEquals("true", returnMessageMap.get("Unlocked"));
-        assertNull(returnMessageMap.get("gisuserrole"));
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, attributesWithoutRole);
+        assertEquals(userName, returnedUser.getUsername());
+        assertEquals(true, returnedUser.isAuthenticated());
+        assertEquals(true, returnedUser.isUnlocked());
+        assertNull(returnedUser.getGisuserrole());
     }
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleTrue() {
-        Map<String, String> returnMessageMap = ldapService.createReturnMessage(userName, true, true, attributesWithRole);
-        assertEquals(userName, returnMessageMap.get("Username"));
-        assertEquals("true", returnMessageMap.get("Authenticated"));
-        assertEquals("true", returnMessageMap.get("Unlocked"));
-        assertEquals("GISUSER", returnMessageMap.get("gisuserrole"));
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, attributesWithRole);
+        assertEquals(userName, returnedUser.getUsername());
+        assertEquals(true, returnedUser.isAuthenticated());
+        assertEquals(true, returnedUser.isUnlocked());
+        assertEquals("GISUSER", returnedUser.getGisuserrole());
     }
 }

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -1,13 +1,17 @@
 package ca.bc.gov.hlth.ldapapi.service;
 
 import ca.bc.gov.hlth.ldapapi.model.User;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttributes;
+import java.time.LocalDateTime;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 public class LdapServiceTest {
 
@@ -15,7 +19,12 @@ public class LdapServiceTest {
     private Attributes attributesWithRole = new BasicAttributes("gisuserrole", "GISUSER");
     private Attributes attributesWithoutRole = new BasicAttributes();
 
-    private LdapService ldapService = new LdapService(new Properties());
+    private static LdapService ldapService = new LdapService(new Properties());
+
+    @BeforeAll
+    public static void initialSetup() {
+        ldapService.attemptTimeout = 1;
+    }
 
     @Test
     public void testCreateReturnMessage_authenticatedFalse() {
@@ -51,5 +60,43 @@ public class LdapServiceTest {
         assertEquals(true, returnedUser.isAuthenticated());
         assertEquals(true, returnedUser.isUnlocked());
         assertEquals("GISUSER", returnedUser.getGisuserrole());
+    }
+
+    @Test
+    public void testUpdateUserFailedLoginAttempts_noEntryHour() {
+        ldapService.loginAttemptsMap.clear();
+        ldapService.updateUserFailedLoginAttempts("bob");
+
+        assertEquals(1, ldapService.loginAttemptsMap.get("bob").getAttempts());
+    }
+
+    @Test
+    public void testUpdateUserFailedLoginAttempts_timeOverOneHour() {
+        ldapService.loginAttemptsMap.clear();
+        ldapService.loginAttemptsMap.put("bob", new LoginAttempts(1, LocalDateTime.now().minusHours(3)));
+        ldapService.updateUserFailedLoginAttempts("bob");
+
+        assertEquals(1, ldapService.loginAttemptsMap.get("bob").getAttempts());
+    }
+
+    @Test
+    public void testUpdateUserFailedLoginAttempts_lessThanTwoFailed() {
+        ldapService.loginAttemptsMap.clear();
+        ldapService.loginAttemptsMap.put("bob", new LoginAttempts(1, LocalDateTime.now()));
+        ldapService.updateUserFailedLoginAttempts("bob");
+
+        assertEquals(2, ldapService.loginAttemptsMap.get("bob").getAttempts());
+    }
+
+    @Test
+    public void testUpdateUserFailedLoginAttempts_lastAttempt() {
+        LdapService localLdapService = spy(new LdapService(new Properties()));
+        doNothing().when(localLdapService).lockUserAccount(anyString());
+
+        localLdapService.loginAttemptsMap.clear();
+        localLdapService.loginAttemptsMap.put("bob", new LoginAttempts(2, LocalDateTime.now()));
+        localLdapService.updateUserFailedLoginAttempts("bob");
+
+        verify(localLdapService, times(1)).lockUserAccount(anyString());
     }
 }


### PR DESCRIPTION
- API now uses a POST instead of a get
- Account locks after 3 failed attempts within a timeframe (specified in properties)