### PR TITLE
Ab#4209 add lockoutTimeInHours and l remainingAttempts attributes to response

### DIFF
--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
@@ -6,8 +6,8 @@ public class User {
     private boolean passwordExpired;
     private String username;
     private String gisuserrole;
-    private long lockoutTimeInHours;
-    private int remainingAttempts;
+    private Long lockoutTimeInHours;
+    private Integer remainingAttempts;
 
     public boolean isAuthenticated() {
         return authenticated;
@@ -49,7 +49,7 @@ public class User {
         this.passwordExpired = passwordExpired;
     }
     
-    public int getRemainingAttempts() {
+    public Integer getRemainingAttempts() {
         return remainingAttempts;
     }
 
@@ -57,7 +57,7 @@ public class User {
         this.remainingAttempts = remainingAttempts;
     }
     
-    public long getLockoutTimeInHours() {
+    public Long getLockoutTimeInHours() {
         return lockoutTimeInHours;
     }
 

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
@@ -6,6 +6,8 @@ public class User {
     private boolean passwordExpired;
     private String username;
     private String gisuserrole;
+    private long lockoutTimeInHours;
+    private int remainingAttempts;
 
     public boolean isAuthenticated() {
         return authenticated;
@@ -46,4 +48,22 @@ public class User {
     public void setPasswordExpired(boolean passwordExpired) {
         this.passwordExpired = passwordExpired;
     }
+    
+    public int getRemainingAttempts() {
+        return remainingAttempts;
+    }
+
+    public void setRemainingAttempts(int remainingAttempts) {
+        this.remainingAttempts = remainingAttempts;
+    }
+    
+    public long getLockoutTimeInHours() {
+        return lockoutTimeInHours;
+    }
+
+    public void setLockoutTimeInHours(long lockoutTimeInHours) {
+        this.lockoutTimeInHours = lockoutTimeInHours;
+    }
+    
+    
 }

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -202,6 +202,8 @@ public class LdapService {
 
         } else { // Entry Exists, timestamp<1hr, attempts >=3
             lockUserAccount(userInfoName + "," + LDAP_SEARCH_BASE);
+            loginAttemptsForUser.setAttempts(currentAttempts + 1);
+            loginAttemptsForUser.setLastAttempt(LocalDateTime.now());
         }
     }
 

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -125,27 +125,6 @@ public class LdapService {
         }
         return expired;
     }
-
-    // TODO
-    private int getNbLoginAttempts(Attributes attributes) {
-        Attribute passwordChangeDate = attributes.get(LDAP_ATTR_PASSWORD_CHANGE_DATE);
-        Attribute passwordLifespan = attributes.get(LDAP_ATTR_PASSLIFESPAN);
-        boolean expired = false;
-
-        if (passwordChangeDate != null) {
-            try {
-                long epochDateLastChangedOn = Long.parseLong(passwordChangeDate.get().toString());
-                long today = LocalDate.now().toEpochDay();
-                expired = (epochDateLastChangedOn + retrievePasswordLifespan(passwordLifespan)) < today;
-            } catch (NamingException | NoSuchElementException e) {
-                /* If we can't get the expired password info we consider expired=false
-                 This is not actually used as part of determining a successful authentication it just suggests for a user
-                 to change their password */
-                webClientLogger.debug(e.getMessage());
-            }
-        }
-        return 1;
-    }
         
     private int retrievePasswordLifespan(Attribute passwordLifespan) throws NamingException {
         int lifespan = 42; // Standard password lifespan setting from LDAPAdmin webapp

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -60,11 +60,9 @@ public class LdapService {
             if (loginAttemptsForUser != null){
                 remainingAttempts = 3 - loginAttemptsForUser.getAttempts();
              
-                long hoursSinceLastAttempt = ChronoUnit.HOURS.between(loginAttemptsForUser.getLastAttempt(), LocalDateTime.now());
-                lockoutTimeInHours = attemptTimeout - hoursSinceLastAttempt;
+                lockoutTimeInHours = ChronoUnit.HOURS.between(loginAttemptsForUser.getLastAttempt(), LocalDateTime.now());
             }
         }
-        
         return createReturnMessage(userInfo.getName(), validCredentials, userUnlocked, userPasswordExpired, lockoutTimeInHours, remainingAttempts, userInfo.getAttributes());
     }
 

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -62,11 +62,6 @@ public class LdapService {
              
                 long hoursSinceLastAttempt = ChronoUnit.HOURS.between(loginAttemptsForUser.getLastAttempt(), LocalDateTime.now());
                 lockoutTimeInHours = attemptTimeout - hoursSinceLastAttempt;
-           
-            // Should never happen
-//           if (hoursSinceLastAttempt > attemptTimeout){
-//               lockoutTimeInHours = 0;
-//            }
             }
         }
         

--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/service/LdapService.java
@@ -46,12 +46,31 @@ public class LdapService {
         SearchResult userInfo = searchUser(userCredentials.getUserName());
         boolean userUnlocked = checkUserLocked(userInfo.getAttributes());
         boolean userPasswordExpired = checkUserPasswordExpired(userInfo.getAttributes());
+
         boolean validCredentials = false;
         if (userUnlocked) {
             validCredentials = authenticateUser(userInfo.getName(), userCredentials.getPassword());
         }
 
-        return createReturnMessage(userInfo.getName(), validCredentials, userUnlocked, userPasswordExpired, userInfo.getAttributes());
+        // Get nbLoginAttempts and lockoutTimeOut after authenticateUser 
+        long lockoutTimeInHours = 0;
+        int remainingAttempts = 3;
+        if (!validCredentials){
+            LoginAttempts loginAttemptsForUser = loginAttemptsMap.get(userInfo.getName());
+            if (loginAttemptsForUser != null){
+                remainingAttempts = 3 - loginAttemptsForUser.getAttempts();
+             
+                long hoursSinceLastAttempt = ChronoUnit.HOURS.between(loginAttemptsForUser.getLastAttempt(), LocalDateTime.now());
+                lockoutTimeInHours = attemptTimeout - hoursSinceLastAttempt;
+           
+            // Should never happen
+//           if (hoursSinceLastAttempt > attemptTimeout){
+//               lockoutTimeInHours = 0;
+//            }
+            }
+        }
+        
+        return createReturnMessage(userInfo.getName(), validCredentials, userUnlocked, userPasswordExpired, lockoutTimeInHours, remainingAttempts, userInfo.getAttributes());
     }
 
     private SearchResult searchUser(String username) {
@@ -107,6 +126,27 @@ public class LdapService {
         return expired;
     }
 
+    // TODO
+    private int getNbLoginAttempts(Attributes attributes) {
+        Attribute passwordChangeDate = attributes.get(LDAP_ATTR_PASSWORD_CHANGE_DATE);
+        Attribute passwordLifespan = attributes.get(LDAP_ATTR_PASSLIFESPAN);
+        boolean expired = false;
+
+        if (passwordChangeDate != null) {
+            try {
+                long epochDateLastChangedOn = Long.parseLong(passwordChangeDate.get().toString());
+                long today = LocalDate.now().toEpochDay();
+                expired = (epochDateLastChangedOn + retrievePasswordLifespan(passwordLifespan)) < today;
+            } catch (NamingException | NoSuchElementException e) {
+                /* If we can't get the expired password info we consider expired=false
+                 This is not actually used as part of determining a successful authentication it just suggests for a user
+                 to change their password */
+                webClientLogger.debug(e.getMessage());
+            }
+        }
+        return 1;
+    }
+        
     private int retrievePasswordLifespan(Attribute passwordLifespan) throws NamingException {
         int lifespan = 42; // Standard password lifespan setting from LDAPAdmin webapp
         if (passwordLifespan != null) {
@@ -152,7 +192,7 @@ public class LdapService {
         long hoursSinceLastAttempt = ChronoUnit.HOURS.between(loginAttemptsForUser.getLastAttempt(), LocalDateTime.now());
         int currentAttempts = loginAttemptsForUser.getAttempts();
         // Entry exists AND timestamp >1hr: set attempts=1, timestamp=now
-        if (hoursSinceLastAttempt > attemptTimeout) {
+        if (hoursSinceLastAttempt > attemptTimeout) { // reset the nb of attempts if the attemptsTimeout has passed
             loginAttemptsForUser.setAttempts(1);
             loginAttemptsForUser.setLastAttempt(LocalDateTime.now());
 
@@ -166,7 +206,8 @@ public class LdapService {
     }
 
     protected User createReturnMessage(String userName, boolean validCredentials, boolean userUnlocked,
-                                       boolean passwordExpired, Attributes attributes) {
+                                       boolean passwordExpired, long lockoutTimeInHours, int remainingAttempts,
+                                       Attributes attributes) {
 
         User userToReturn = new User();
         userToReturn.setUsername(userName);
@@ -185,11 +226,14 @@ public class LdapService {
                     e.printStackTrace(); // TODO we should return a 500 here
                 }
             }
+        } else if (!validCredentials) {
+            userToReturn.setLockoutTimeInHours(lockoutTimeInHours);
+            userToReturn.setRemainingAttempts(remainingAttempts);
         }
 
         return userToReturn;
     }
-
+        
     protected void lockUserAccount(String userInfoName) {
         try {
             DirContext ctx = new InitialDirContext(ldapProperties);

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -54,8 +54,10 @@ public class LdapServiceTest {
         assertFalse(returnedUser.isUnlocked());
         assertFalse(returnedUser.isPasswordExpired());
         assertNull(returnedUser.getGisuserrole());
-        assertEquals(0, returnedUser.getLockoutTimeInHours());
-        assertEquals(0, returnedUser.getRemainingAttempts());
+        assertNull(returnedUser.getLockoutTimeInHours());
+        assertNull(returnedUser.getRemainingAttempts());
+//        assertEquals(0, returnedUser.getLockoutTimeInHours());
+//        assertEquals(0, returnedUser.getRemainingAttempts());
     }
 
     @Test

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -28,26 +28,39 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, false, true, true, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, false, true, true,0,3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertFalse(returnedUser.isAuthenticated());
         assertFalse(returnedUser.isPasswordExpired());
         assertNull(returnedUser.getGisuserrole());
     }
+    
+    @Test
+    public void testCreateReturnMessage_authenticatedFalseWithRemainingAttempts() {
+        User returnedUser = ldapService.createReturnMessage(userName, false, true, true, 1, 1, attributesWithRole);
+        assertEquals(userName, returnedUser.getUsername());
+        assertFalse(returnedUser.isAuthenticated());
+        assertFalse(returnedUser.isPasswordExpired());
+        assertEquals(1, returnedUser.getLockoutTimeInHours());
+        assertEquals(1, returnedUser.getRemainingAttempts());
+        assertNull(returnedUser.getGisuserrole());
+    }
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_userUnlockedFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, false, true, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, false, true,0,3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertFalse(returnedUser.isUnlocked());
         assertFalse(returnedUser.isPasswordExpired());
         assertNull(returnedUser.getGisuserrole());
+        assertEquals(0, returnedUser.getLockoutTimeInHours());
+        assertEquals(0, returnedUser.getRemainingAttempts());
     }
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, true, false, attributesWithoutRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, false,0,3, attributesWithoutRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertTrue(returnedUser.isUnlocked());
@@ -57,7 +70,7 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleTrue() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, true, true, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, true,0,3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertTrue(returnedUser.isUnlocked());


### PR DESCRIPTION
this 2 attributes are added to the response when the authentication fails.

Last remaining question is what the values should be when the account is locked.
User unlocked, but authentication unsuccessful, first trial
"authenticated":false,"unlocked":true,"passwordExpired":false,"username":"uid=train96,o=Ministry of Health","lockoutTimeInHours":1,"remainingAttempts":2"

User unlocked, but authentication unsuccessful, second trial
"authenticated":false,"unlocked":true,"passwordExpired":false,"username":"uid=train96,o=Ministry of Health","lockoutTimeInHours":1,"remainingAttempts":1"

User locked, authentication unsuccessful, last trial
"authenticated":false,"unlocked":true,"passwordExpired":false,"username":"uid=train96,o=Ministry of Health","lockoutTimeInHours":**1**,"remainingAttempts":**0**"
