### PR TITLE
AB#4325 Fix three bugs

### DIFF
--- a/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
+++ b/ldap-api/src/main/java/ca/bc/gov/hlth/ldapapi/model/User.java
@@ -3,7 +3,6 @@ package ca.bc.gov.hlth.ldapapi.model;
 public class User {
     private boolean authenticated;
     private boolean unlocked;
-    private boolean passwordExpired;
     private String username;
     private String gisuserrole;
     private Long lockoutTimeInHours;
@@ -39,14 +38,6 @@ public class User {
 
     public void setGisuserrole(String gisuserrole) {
         this.gisuserrole = gisuserrole;
-    }
-
-    public boolean isPasswordExpired() {
-        return passwordExpired;
-    }
-
-    public void setPasswordExpired(boolean passwordExpired) {
-        this.passwordExpired = passwordExpired;
     }
     
     public Integer getRemainingAttempts() {

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -28,11 +28,12 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, false, true, 0,3, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, false, true, 0, 3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertFalse(returnedUser.isAuthenticated());
         assertNull(returnedUser.getGisuserrole());
     }
+
     @Test
     public void testCreateReturnMessage_authenticatedFalseWithRemainingAttempts() {
         User returnedUser = ldapService.createReturnMessage(userName, false, true, 1, 1, attributesWithRole);
@@ -45,7 +46,7 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_userUnlockedFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, false, 0,3, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, false, 0, 3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertFalse(returnedUser.isUnlocked());
@@ -58,7 +59,7 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, true, 0,3, attributesWithoutRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, 0, 3, attributesWithoutRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertTrue(returnedUser.isUnlocked());
@@ -67,7 +68,7 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleTrue() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, true, 0,3, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, 0, 3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertTrue(returnedUser.isUnlocked());

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -28,19 +28,17 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, false, true, true,0,3, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, false, true, 0,3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertFalse(returnedUser.isAuthenticated());
-        assertFalse(returnedUser.isPasswordExpired());
         assertNull(returnedUser.getGisuserrole());
     }
     
     @Test
     public void testCreateReturnMessage_authenticatedFalseWithRemainingAttempts() {
-        User returnedUser = ldapService.createReturnMessage(userName, false, true, true, 1, 1, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, false, true, 1, 1, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertFalse(returnedUser.isAuthenticated());
-        assertFalse(returnedUser.isPasswordExpired());
         assertEquals(1, returnedUser.getLockoutTimeInHours());
         assertEquals(1, returnedUser.getRemainingAttempts());
         assertNull(returnedUser.getGisuserrole());
@@ -48,11 +46,10 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_userUnlockedFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, false, true,0,3, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, false, 0,3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertFalse(returnedUser.isUnlocked());
-        assertFalse(returnedUser.isPasswordExpired());
         assertNull(returnedUser.getGisuserrole());
         assertNull(returnedUser.getLockoutTimeInHours());
         assertNull(returnedUser.getRemainingAttempts());
@@ -62,21 +59,19 @@ public class LdapServiceTest {
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleFalse() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, true, false,0,3, attributesWithoutRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, 0,3, attributesWithoutRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertTrue(returnedUser.isUnlocked());
-        assertFalse(returnedUser.isPasswordExpired());
         assertNull(returnedUser.getGisuserrole());
     }
 
     @Test
     public void testCreateReturnMessage_authenticatedTrue_RoleTrue() {
-        User returnedUser = ldapService.createReturnMessage(userName, true, true, true,0,3, attributesWithRole);
+        User returnedUser = ldapService.createReturnMessage(userName, true, true, 0,3, attributesWithRole);
         assertEquals(userName, returnedUser.getUsername());
         assertTrue(returnedUser.isAuthenticated());
         assertTrue(returnedUser.isUnlocked());
-        assertTrue(returnedUser.isPasswordExpired());
         assertEquals("GISUSER", returnedUser.getGisuserrole());
     }
 

--- a/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
+++ b/ldap-api/src/test/java/ca/bc/gov/hlth/ldapapi/service/LdapServiceTest.java
@@ -33,7 +33,6 @@ public class LdapServiceTest {
         assertFalse(returnedUser.isAuthenticated());
         assertNull(returnedUser.getGisuserrole());
     }
-    
     @Test
     public void testCreateReturnMessage_authenticatedFalseWithRemainingAttempts() {
         User returnedUser = ldapService.createReturnMessage(userName, false, true, 1, 1, attributesWithRole);


### PR DESCRIPTION
NOTE: I expect this API won't be around for long, so while I'm trying to make it relatively bug free, I'm not spending much time on Javadoc or even design.

Bugs: 
(1) retry attempts should reset when account locked, 
(2) api should return unlocked: false when account locked, and 
(3) api should not throw exception when password lifespan empty.